### PR TITLE
embed commands doesn’t work

### DIFF
--- a/.env
+++ b/.env
@@ -19,3 +19,5 @@ APP_SECRET=516b33ddaa4c0a4132d1219388292885
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 ###< symfony/framework-bundle ###
+
+SOURCE_VERSION=$(git rev-parse HEAD)


### PR DESCRIPTION
Project created with `symfony new dotenv-reproducer --version=lts`

Adding `SOURCE_VERSION=$(git rev-parse HEAD)` following the documentation about `Embed commands` makes the application crash when running `composer dump-env prod`:

```shell
PHP Fatal error:  Uncaught Error: Call to undefined method Symfony\Component\Process\Process::inheritEnvironmentVariables() in /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php:406
Stack trace:
#0 [internal function]: Symfony\Component\Dotenv\Dotenv->Symfony\Component\Dotenv\{closure}(Array)
#1 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(389): preg_replace_callback('/\n            (...', Object(Closure), '$(git rev-parse...')
#2 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(320): Symfony\Component\Dotenv\Dotenv->resolveCommands('$(git rev-parse...', Array)
#3 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(200): Symfony\Component\Dotenv\Dotenv->lexValue()
#4 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(513): Symfony\Component\Dotenv\Dotenv->parse('# In all enviro...', './.env')
#5 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(65): Symf in /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php on line 406

Fatal error: Uncaught Error: Call to undefined method Symfony\Component\Process\Process::inheritEnvironmentVariables() in /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php:406
Stack trace:
#0 [internal function]: Symfony\Component\Dotenv\Dotenv->Symfony\Component\Dotenv\{closure}(Array)
#1 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(389): preg_replace_callback('/\n            (...', Object(Closure), '$(git rev-parse...')
#2 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(320): Symfony\Component\Dotenv\Dotenv->resolveCommands('$(git rev-parse...', Array)
#3 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(200): Symfony\Component\Dotenv\Dotenv->lexValue()
#4 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(513): Symfony\Component\Dotenv\Dotenv->parse('# In all enviro...', './.env')
#5 /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php(65): Symf in /Users/tbessoussa/workspace/dotenv-reproducer/vendor/symfony/dotenv/Dotenv.php on line 406
```

It also do the same on `platform.sh`

I tried on MacOS, with zsh shell, running with `PHP 7.4.9`
Debian 10, `PHP 7.4.10` on `Symfony LTS 4.4.13` 



